### PR TITLE
[ui-refactor] 공개 프로필 email 표시 제거 및 User 타입 정리 (#11)

### DIFF
--- a/.github/ISSUE_TEMPLATE/task.yml
+++ b/.github/ISSUE_TEMPLATE/task.yml
@@ -28,9 +28,18 @@ body:
     id: what
     attributes:
       label: 작업 내용 / 기대 결과
-      description: 무엇을 해야 하는지와 완료 후 기대 동작.
+      description: 무엇을 해야 하는지와 완료 후 기대 동작. FE↔BE 공유 계약의 구체 필드는 상위 추적 이슈의 "공유 계약" 섹션을 참조(복제 금지).
     validations:
       required: true
+  - type: textarea
+    id: non_goals
+    attributes:
+      label: 범위 밖 (Non-goals)
+      description: 이번 이슈에서 의도적으로 하지 않는 것. 스코프 크립·재검토를 막는다. 없으면 "없음".
+      placeholder: |
+        - ...는 이번 범위에서 제외 (별도 이슈)
+    validations:
+      required: false
   - type: textarea
     id: bug_detail
     attributes:
@@ -64,11 +73,12 @@ body:
     id: validation
     attributes:
       label: 검증 방법
+      description: 테스트 러너가 없으므로 브라우저 QA는 "경로 → 동작 → 기대/비기대 상태"의 구체 시나리오로 적어 체크 가능하게 만든다.
       placeholder: |
         - `npm run lint`
         - `npm run typecheck`
         - `npm run build`
-        - 스크린샷 / 브라우저 QA
+        - 브라우저 QA: <경로> 접속 → <동작> → <기대 상태 / 보이면 안 되는 것>
     validations:
       required: true
   - type: textarea

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -101,7 +101,7 @@ export default function SettingsPage() {
                                         {user.username}
                                     </p>
                                     <p className="text-[14px] text-muted-foreground truncate mt-0.5">
-                                        {user.email || t("settings.account.logged-in-with-github")}
+                                        {t("settings.account.logged-in-with-github")}
                                     </p>
                                 </div>
                             </div>

--- a/src/shared/components/layout/header.tsx
+++ b/src/shared/components/layout/header.tsx
@@ -128,9 +128,6 @@ export function Header() {
                                         </Avatar>
                                         <div className="flex-1 min-w-0">
                                             <p className="text-[15px] font-semibold text-foreground truncate">{user.username}</p>
-                                            <p className="text-[13px] text-muted-foreground truncate mt-0.5">
-                                                {user.email}
-                                            </p>
                                         </div>
                                     </div>
                                 </div>

--- a/src/shared/types/api.ts
+++ b/src/shared/types/api.ts
@@ -36,13 +36,9 @@ export interface AuthMeResponse {
 }
 
 export interface User {
-  userId: number;
-  githubId: number;
   nodeId: string;
   username: string;
-  email: string | null;
   profileImage: string;
-  role: UserRole;
   updatedAt: string;
   lastFullScanAt: string;
   totalScore: number;
@@ -64,9 +60,7 @@ export interface UserStats {
   diffReviewCount: number;
 }
 
-export interface RegisterUserResponse extends User, UserStats {
-  isNewUser: boolean;
-}
+export type RegisterUserResponse = User & UserStats;
 
 export interface RankingUserInfo {
   username: string;


### PR DESCRIPTION
## 배경
로그인 사용자 본인의 `email`을 공개 프로필 엔드포인트(`GET /users/{username}`) 응답에서 소싱해 Settings·헤더에 표시하고 있었다. 이 email은 OAuth `user:email` 스코프 값으로 공개 응답에 실려 PII로 노출된다. 옵션 B에 따라 본인 email 표시를 제거하고 공개 응답 의존을 끊는다. (추적 #106 P0-1)

## 변경
- `src/app/settings/page.tsx`: `user.email` 표시 제거 → 기존 fallback 문구(`settings.account.logged-in-with-github`)만 노출
- `src/shared/components/layout/header.tsx`: 드롭다운의 email `<p>` 줄 완전 제거 (username만 표시)
- `src/shared/types/api.ts`: 공개 응답 미러 타입 정리
  - `User`에서 제외 필드 `userId`·`githubId`·`email`·`role` 제거, 포함 필드 유지
  - `RegisterUserResponse`를 `type RegisterUserResponse = User & UserStats`로 전환(`isNewUser` 제거) → 계약 `PublicUserResponse` 19필드와 정확히 일치

## 결정 사항
- `isNewUser`도 제거해 `PublicUserResponse`(#106 계약)와 완전 일치시킴
- 헤더는 fallback 문구 없이 email 줄만 제거(username만 표시)

## 검증
- [x] `npm run lint`
- [x] `npm run typecheck` (제거 필드 잔존 참조 없음 확인)
- [x] `npm run test` (22 passed)
- [x] `npm run build`

UI 표시 제거 + 타입 미러 변경이라 순수 로직 변경이 없어 신규 단위 테스트를 추가하지 않음(이 레포는 vitest 순수 로직 단위 테스트만 있고 컴포넌트/E2E harness 미도입).

### 남은 QA (수동, 로그인 세션 필요)
- `/settings`(로그인): email 미표시 & "GitHub 계정으로 로그인됨" fallback 표시
- 헤더 드롭다운(로그인): email 미표시, username만 표시
- 공개 프로필 `/users/{username}`: 프로필·통계 정상 렌더

## 의존성
- 상위 추적: alexization/git-ranker-workflow#106
- 연관 BE: alexization/git-ranker#91 — **이 FE 변경이 먼저 배포**되어야 계약 불일치 없음 (#106 G3)

Closes #11